### PR TITLE
Feature: Configurable Git and GitHub CLI Command Approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The Haleon fork includes several experimental features for agentic research that
 |---------|-------------|---------------|
 | **GitHub CLI Integration** | Seamlessly interact with GitHub directly from Codex. Create issues, manage PRs, and run workflows using the `gh` CLI. Requires [GitHub CLI](https://cli.github.com/) to be installed. | `gh issue create "Bug title" "Description"` <br> `gh pr create --title "Feature" --body "Implements X"` |
 | **Direct Command Execution** | Execute shell commands directly with fine-grained context control. Use prefixes to control whether command output is added to AI context. See [detailed documentation](./docs/features/direct-command-execution.md). | `!ls -la` (execute without adding to context) <br> `$cat file.txt` (execute and add output to context) |
+| **Git & GitHub CLI Approval Config** | Configure which Git and GitHub CLI commands require approval and which can be auto-approved. See [detailed documentation](./docs/features/git-github-approval-config.md). | `codex --git-approval=prompt` <br> `codex --github-approval=auto` |
 
 > **Warning**: These experimental features are for research purposes only and may change without notice. They are not supported for production use.
 

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ The Haleon fork includes several experimental features for agentic research that
 | Feature | Description | Usage Example |
 |---------|-------------|---------------|
 | **GitHub CLI Integration** | Seamlessly interact with GitHub directly from Codex. Create issues, manage PRs, and run workflows using the `gh` CLI. Requires [GitHub CLI](https://cli.github.com/) to be installed. | `gh issue create "Bug title" "Description"` <br> `gh pr create --title "Feature" --body "Implements X"` |
+| **Direct Command Execution** | Execute shell commands directly with fine-grained context control. Use prefixes to control whether command output is added to AI context. See [detailed documentation](./docs/features/direct-command-execution.md). | `!ls -la` (execute without adding to context) <br> `$cat file.txt` (execute and add output to context) |
 
 > **Warning**: These experimental features are for research purposes only and may change without notice. They are not supported for production use.
 

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -55,6 +55,18 @@ export default function HelpOverlay({
         <Text>
           <Text color="cyan">/compact</Text> – condense context into a summary
         </Text>
+        
+        <Box marginTop={1}>
+          <Text bold dimColor>
+            Direct commands
+          </Text>
+        </Box>
+        <Text>
+          <Text color="magenta">!</Text><Text color="gray">command</Text> – execute shell command without adding to context
+        </Text>
+        <Text>
+          <Text color="magenta">$</Text><Text color="gray">command</Text> – execute shell command and add output to context
+        </Text>
 
         <Box marginTop={1}>
           <Text bold dimColor>

--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -103,7 +103,7 @@ export async function handleExecCommand(
   // working directory so that edits are constrained to the project root.  If
   // the caller wishes to broaden or restrict the set it can be made
   // configurable in the future.
-  const safety = canAutoApprove(command, policy, [process.cwd()]);
+  const safety = canAutoApprove(command, policy, [process.cwd()], process.env, config);
 
   let runInSandbox: boolean;
   switch (safety.type) {

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -60,6 +60,16 @@ export type StoredConfig = {
     autoApprove?: boolean;
     addToContext?: boolean;
   };
+  git?: {
+    requireApprovalByDefault?: boolean;
+    autoApprovedCommands?: Array<string>;
+    requireApprovalCommands?: Array<string>;
+  };
+  githubCli?: {
+    requireApprovalByDefault?: boolean;
+    autoApprovedCommands?: Array<string>;
+    requireApprovalCommands?: Array<string>;
+  };
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
@@ -91,6 +101,16 @@ export type AppConfig = {
   directCommands?: {
     autoApprove?: boolean;
     addToContext?: boolean;
+  };
+  git?: {
+    requireApprovalByDefault: boolean;
+    autoApprovedCommands: Array<string>;
+    requireApprovalCommands: Array<string>;
+  };
+  githubCli?: {
+    requireApprovalByDefault: boolean;
+    autoApprovedCommands: Array<string>;
+    requireApprovalCommands: Array<string>;
   };
 };
 
@@ -360,6 +380,34 @@ export const loadConfig = (
       addToContext: storedConfig.directCommands.addToContext ?? false,
     };
   }
+  
+  // Load Git approval settings with defaults
+  config.git = {
+    // Git commands require approval by default for safety
+    requireApprovalByDefault: storedConfig.git?.requireApprovalByDefault ?? true,
+    // Default auto-approved Git commands (read-only commands)
+    autoApprovedCommands: storedConfig.git?.autoApprovedCommands ?? [
+      "status", "log", "diff", "branch", "show"
+    ],
+    // Default commands that always require approval (potentially destructive)
+    requireApprovalCommands: storedConfig.git?.requireApprovalCommands ?? [
+      "commit", "push", "merge", "rebase", "reset", "checkout"
+    ]
+  };
+  
+  // Load GitHub CLI approval settings with defaults
+  config.githubCli = {
+    // GitHub CLI commands are auto-approved by default (continuing current behavior)
+    requireApprovalByDefault: storedConfig.githubCli?.requireApprovalByDefault ?? false,
+    // Default auto-approved GitHub CLI commands (read-only commands)
+    autoApprovedCommands: storedConfig.githubCli?.autoApprovedCommands ?? [
+      "issue list", "issue view", "pr list", "pr view", "workflow list", "workflow view"
+    ],
+    // Default commands that always require approval (potentially destructive)
+    requireApprovalCommands: storedConfig.githubCli?.requireApprovalCommands ?? [
+      "pr create", "pr merge", "issue create", "issue close"
+    ]
+  };
 
   return config;
 };
@@ -408,6 +456,24 @@ export const saveConfig = (
     configToSave.directCommands = {
       autoApprove: config.directCommands.autoApprove,
       addToContext: config.directCommands.addToContext,
+    };
+  }
+  
+  // Add Git approval settings if they exist
+  if (config.git) {
+    configToSave.git = {
+      requireApprovalByDefault: config.git.requireApprovalByDefault,
+      autoApprovedCommands: config.git.autoApprovedCommands,
+      requireApprovalCommands: config.git.requireApprovalCommands,
+    };
+  }
+  
+  // Add GitHub CLI approval settings if they exist
+  if (config.githubCli) {
+    configToSave.githubCli = {
+      requireApprovalByDefault: config.githubCli.requireApprovalByDefault,
+      autoApprovedCommands: config.githubCli.autoApprovedCommands,
+      requireApprovalCommands: config.githubCli.requireApprovalCommands,
     };
   }
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -56,6 +56,10 @@ export type StoredConfig = {
     saveHistory?: boolean;
     sensitivePatterns?: Array<string>;
   };
+  directCommands?: {
+    autoApprove?: boolean;
+    addToContext?: boolean;
+  };
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
@@ -83,6 +87,10 @@ export type AppConfig = {
     maxSize: number;
     saveHistory: boolean;
     sensitivePatterns: Array<string>;
+  };
+  directCommands?: {
+    autoApprove?: boolean;
+    addToContext?: boolean;
   };
 };
 
@@ -344,6 +352,14 @@ export const loadConfig = (
       sensitivePatterns: [],
     };
   }
+  
+  // Load direct commands settings if provided
+  if (storedConfig.directCommands !== undefined) {
+    config.directCommands = {
+      autoApprove: storedConfig.directCommands.autoApprove ?? false,
+      addToContext: storedConfig.directCommands.addToContext ?? false,
+    };
+  }
 
   return config;
 };
@@ -384,6 +400,14 @@ export const saveConfig = (
       maxSize: config.history.maxSize,
       saveHistory: config.history.saveHistory,
       sensitivePatterns: config.history.sensitivePatterns,
+    };
+  }
+  
+  // Add direct commands settings if they exist
+  if (config.directCommands) {
+    configToSave.directCommands = {
+      autoApprove: config.directCommands.autoApprove,
+      addToContext: config.directCommands.addToContext,
     };
   }
 

--- a/codex-cli/src/utils/direct-command.ts
+++ b/codex-cli/src/utils/direct-command.ts
@@ -1,0 +1,122 @@
+import type { CommandConfirmation } from "./agent/agent-loop.js";
+import type { ApplyPatchCommand } from "../approvals.js";
+import type { AppConfig } from "./config.js";
+import type { ExecResult } from "./agent/sandbox/interface.js";
+import { handleExecCommand } from "./agent/handle-exec-command.js";
+import { ReviewDecision } from "./agent/review.js";
+import { parse } from "shell-quote";
+
+/**
+ * Handler for direct command execution with prefixed commands (! or $)
+ * ! - Execute command without adding to context
+ * $ - Execute command and add output to context
+ */
+export async function handleDirectCommand(
+  rawCommand: string,
+  config: AppConfig,
+  getCommandConfirmation: (
+    command: Array<string>,
+    applyPatch: ApplyPatchCommand | undefined,
+  ) => Promise<CommandConfirmation>
+): Promise<DirectCommandResult> {
+  // Strip the prefix (! or $)
+  const prefix = rawCommand.charAt(0);
+  const command = rawCommand.slice(1).trim();
+  
+  // Split into argument array using shell-quote for proper parsing
+  const args = parseCommandIntoArgs(command);
+  
+  // Use either auto-approval or standard approval flow based on configuration
+  const approval = getApproval(config, getCommandConfirmation);
+  
+  // Use the existing execution path
+  const result = await handleExecCommand(
+    { cmd: args },
+    config,
+    'auto-edit', // Use existing approval mode
+    [], // No additional writable roots
+    approval
+  );
+  
+  // Determine if we should add this command output to context
+  // $ prefix always adds to context
+  // ! prefix never adds to context
+  // The config setting is only used for $ prefix as an additional gate
+  const addToContext = prefix === '$' && 
+    (config.directCommands?.addToContext !== false);
+  
+  return {
+    outputText: result.outputText,
+    metadata: result.metadata,
+    prefix,
+    originalCommand: rawCommand,
+    addToContext
+  };
+}
+
+/**
+ * Determines whether to use auto-approval or standard approval workflow
+ * based on user configuration
+ */
+function getApproval(
+  config: AppConfig, 
+  getCommandConfirmation: (
+    command: Array<string>,
+    applyPatch: ApplyPatchCommand | undefined,
+  ) => Promise<CommandConfirmation>
+): (
+  command: Array<string>,
+  applyPatch: ApplyPatchCommand | undefined,
+) => Promise<CommandConfirmation> {
+  // Check if user has explicitly opted in to auto-approval for direct commands
+  const autoApprove = config.directCommands?.autoApprove === true;
+  
+  if (autoApprove) {
+    // Auto-approve if user has explicitly enabled this in config
+    return async (command: Array<string>, applyPatch?: ApplyPatchCommand): 
+      Promise<CommandConfirmation> => {
+      return {
+        review: ReviewDecision.YES,
+        command
+      };
+    };
+  } else {
+    // Otherwise use the standard approval flow
+    // This will prompt the user for confirmation
+    return getCommandConfirmation;
+  }
+}
+
+/**
+ * Utility to parse command string into args array
+ * using shell-quote to handle quotes, escapes, etc.
+ */
+function parseCommandIntoArgs(command: string): string[] {
+  try {
+    const parsed = parse(command);
+    // Convert all items to strings and filter out any non-string elements
+    return parsed.filter(item => typeof item === 'string') as string[];
+  } catch (error) {
+    // If parsing fails, fall back to a simple split by space
+    return command.split(/\s+/).filter(Boolean);
+  }
+}
+
+/**
+ * Extended ExecResult type with prefix and original command information
+ */
+export interface DirectCommandResult extends ExecResult {
+  prefix: string;
+  originalCommand: string;
+  addToContext: boolean;
+}
+
+/**
+ * Check if a result is from a direct command
+ */
+export function isDirectCommandResult(result: any): result is DirectCommandResult {
+  return result && 
+    typeof result.prefix === 'string' && 
+    typeof result.originalCommand === 'string' &&
+    typeof result.addToContext === 'boolean';
+}

--- a/codex-cli/tests/direct-command.test.ts
+++ b/codex-cli/tests/direct-command.test.ts
@@ -1,0 +1,169 @@
+import { handleDirectCommand, isDirectCommandResult } from "../src/utils/direct-command.js";
+import { ReviewDecision } from "../src/utils/agent/review.js";
+import { expect, test, vi, describe } from "vitest";
+
+describe("Direct command execution", () => {
+  test("isDirectCommandResult correctly identifies DirectCommandResult", () => {
+    // Valid direct command result
+    const validResult = {
+      outputText: "test output",
+      metadata: {},
+      prefix: "!",
+      originalCommand: "!ls",
+      addToContext: false
+    };
+    
+    // Invalid results
+    const missingPrefix = {
+      outputText: "test output",
+      metadata: {},
+      originalCommand: "!ls",
+      addToContext: false
+    };
+    
+    const missingOriginalCommand = {
+      outputText: "test output",
+      metadata: {},
+      prefix: "!",
+      addToContext: false
+    };
+    
+    const missingAddToContext = {
+      outputText: "test output",
+      metadata: {},
+      prefix: "!",
+      originalCommand: "!ls"
+    };
+    
+    expect(isDirectCommandResult(validResult)).toBe(true);
+    expect(isDirectCommandResult(missingPrefix)).toBe(false);
+    expect(isDirectCommandResult(missingOriginalCommand)).toBe(false);
+    expect(isDirectCommandResult(missingAddToContext)).toBe(false);
+  });
+  
+  test("handleDirectCommand with ! prefix does not add to context", async () => {
+    // Mock the exec command handler
+    const mockExecCommand = vi.fn().mockResolvedValue({
+      outputText: "test output",
+      metadata: {}
+    });
+    
+    // Mock the getCommandConfirmation function
+    const mockGetCommandConfirmation = vi.fn().mockResolvedValue({
+      review: ReviewDecision.YES,
+      command: ["ls"]
+    });
+    
+    // Create a mock config
+    const mockConfig = {
+      model: "test-model",
+      instructions: "",
+      notify: false,
+      directCommands: {
+        autoApprove: true,
+        addToContext: true
+      }
+    };
+    
+    // Replace the imported handleExecCommand with our mock
+    vi.mock("../src/utils/agent/handle-exec-command.js", () => ({
+      handleExecCommand: mockExecCommand
+    }));
+    
+    // Call the function with ! prefix
+    const result = await handleDirectCommand(
+      "!ls -la",
+      mockConfig,
+      mockGetCommandConfirmation
+    );
+    
+    // Verify the result
+    expect(result.prefix).toBe("!");
+    expect(result.originalCommand).toBe("!ls -la");
+    expect(result.addToContext).toBe(false);  // ! prefix should never add to context
+  });
+  
+  test("handleDirectCommand with $ prefix does add to context", async () => {
+    // Mock the exec command handler
+    const mockExecCommand = vi.fn().mockResolvedValue({
+      outputText: "test output",
+      metadata: {}
+    });
+    
+    // Mock the getCommandConfirmation function
+    const mockGetCommandConfirmation = vi.fn().mockResolvedValue({
+      review: ReviewDecision.YES,
+      command: ["ls"]
+    });
+    
+    // Create a mock config
+    const mockConfig = {
+      model: "test-model",
+      instructions: "",
+      notify: false,
+      directCommands: {
+        autoApprove: true,
+        addToContext: true
+      }
+    };
+    
+    // Replace the imported handleExecCommand with our mock
+    vi.mock("../src/utils/agent/handle-exec-command.js", () => ({
+      handleExecCommand: mockExecCommand
+    }));
+    
+    // Call the function with $ prefix
+    const result = await handleDirectCommand(
+      "$ls -la",
+      mockConfig,
+      mockGetCommandConfirmation
+    );
+    
+    // Verify the result
+    expect(result.prefix).toBe("$");
+    expect(result.originalCommand).toBe("$ls -la");
+    expect(result.addToContext).toBe(true);  // $ prefix should add to context when config allows
+  });
+  
+  test("handleDirectCommand respects config.directCommands.addToContext setting", async () => {
+    // Mock the exec command handler
+    const mockExecCommand = vi.fn().mockResolvedValue({
+      outputText: "test output",
+      metadata: {}
+    });
+    
+    // Mock the getCommandConfirmation function
+    const mockGetCommandConfirmation = vi.fn().mockResolvedValue({
+      review: ReviewDecision.YES,
+      command: ["ls"]
+    });
+    
+    // Create a mock config with addToContext disabled
+    const mockConfig = {
+      model: "test-model",
+      instructions: "",
+      notify: false,
+      directCommands: {
+        autoApprove: true,
+        addToContext: false
+      }
+    };
+    
+    // Replace the imported handleExecCommand with our mock
+    vi.mock("../src/utils/agent/handle-exec-command.js", () => ({
+      handleExecCommand: mockExecCommand
+    }));
+    
+    // Call the function with $ prefix
+    const result = await handleDirectCommand(
+      "$ls -la",
+      mockConfig,
+      mockGetCommandConfirmation
+    );
+    
+    // Verify the result
+    expect(result.prefix).toBe("$");
+    expect(result.originalCommand).toBe("$ls -la");
+    expect(result.addToContext).toBe(false);  // Even with $ prefix, config setting disables adding to context
+  });
+});

--- a/codex-cli/tests/git-github-approval.test.ts
+++ b/codex-cli/tests/git-github-approval.test.ts
@@ -1,0 +1,78 @@
+import { isSafeCommand, canAutoApprove } from "../src/approvals.js";
+import { expect, test, describe } from "vitest";
+
+describe("Git & GitHub CLI approval configuration", () => {
+  test("Git commands respect requireApprovalByDefault setting", () => {
+    // Create a test config
+    const testConfig = {
+      git: {
+        requireApprovalByDefault: true,
+        autoApprovedCommands: ["status", "log"],
+        requireApprovalCommands: ["commit", "push"]
+      }
+    };
+    
+    // When requireApprovalByDefault is true, commands not in autoApprovedCommands should require approval
+    expect(isSafeCommand(["git", "status"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["git", "log"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["git", "commit"], testConfig)).toBeNull();
+    expect(isSafeCommand(["git", "push"], testConfig)).toBeNull();
+    expect(isSafeCommand(["git", "branch"], testConfig)).toBeNull(); // Not explicitly allowed or denied
+    
+    // Flip the default setting
+    testConfig.git.requireApprovalByDefault = false;
+    
+    // Now commands not explicitly denied should be auto-approved
+    expect(isSafeCommand(["git", "status"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["git", "log"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["git", "commit"], testConfig)).toBeNull(); // Still denied
+    expect(isSafeCommand(["git", "push"], testConfig)).toBeNull(); // Still denied
+    expect(isSafeCommand(["git", "branch"], testConfig)).not.toBeNull(); // Now allowed
+  });
+  
+  test("GitHub CLI commands respect requireApprovalByDefault setting", () => {
+    // Create a test config
+    const testConfig = {
+      githubCli: {
+        requireApprovalByDefault: false,
+        autoApprovedCommands: ["issue list", "pr list"],
+        requireApprovalCommands: ["pr create", "issue close"]
+      }
+    };
+    
+    // When requireApprovalByDefault is false, commands not in requireApprovalCommands should be auto-approved
+    expect(isSafeCommand(["gh", "issue", "list"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["gh", "pr", "list"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["gh", "pr", "create"], testConfig)).toBeNull();
+    expect(isSafeCommand(["gh", "issue", "close"], testConfig)).toBeNull();
+    expect(isSafeCommand(["gh", "workflow", "list"], testConfig)).not.toBeNull(); // Not explicitly denied
+    
+    // Flip the default setting
+    testConfig.githubCli.requireApprovalByDefault = true;
+    
+    // Now commands not explicitly allowed should require approval
+    expect(isSafeCommand(["gh", "issue", "list"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["gh", "pr", "list"], testConfig)).not.toBeNull();
+    expect(isSafeCommand(["gh", "pr", "create"], testConfig)).toBeNull(); // Still denied
+    expect(isSafeCommand(["gh", "issue", "close"], testConfig)).toBeNull(); // Still denied
+    expect(isSafeCommand(["gh", "workflow", "list"], testConfig)).toBeNull(); // Now denied
+  });
+  
+  test("canAutoApprove passes config to isSafeCommand", () => {
+    // Create a test config
+    const testConfig = {
+      git: {
+        requireApprovalByDefault: true,
+        autoApprovedCommands: ["status"],
+        requireApprovalCommands: ["commit"]
+      }
+    };
+    
+    // Test with config
+    const allowedResult = canAutoApprove(["git", "status"], "suggest", [process.cwd()], process.env, testConfig);
+    const deniedResult = canAutoApprove(["git", "commit"], "suggest", [process.cwd()], process.env, testConfig);
+    
+    expect(allowedResult.type).toBe("auto-approve");
+    expect(deniedResult.type).toBe("ask-user");
+  });
+});

--- a/docs/features/direct-command-execution.md
+++ b/docs/features/direct-command-execution.md
@@ -1,0 +1,161 @@
+# Direct Command Execution in Codex: A Comprehensive Guide
+
+## Introduction
+
+Direct Command Execution is a powerful feature in Codex that allows you to execute shell commands directly without requiring AI processing. This feature provides two distinct command prefixes (`!` and `$`) that offer fine-grained control over how command execution interacts with your AI session context.
+
+## Command Prefixes: `!` vs `$`
+
+### The `!` Command Prefix
+- **Purpose**: Execute commands without adding their output to the AI's context
+- **Syntax**: `!your-command-here`
+- **Example**: `!ls -la`
+- **Result**: The command runs and you see the output, but the AI has no knowledge of this command or its results
+
+### The `$` Command Prefix
+- **Purpose**: Execute commands AND add their output to the AI's context
+- **Syntax**: `$your-command-here`
+- **Example**: `$cat package.json`
+- **Result**: The command runs, you see the output, AND the AI has access to both the command and its output in future interactions
+
+## Configuration Options
+
+Direct commands can be configured through your `~/.codex/config.json` file:
+
+```json
+{
+  "directCommands": {
+    "autoApprove": true,
+    "addToContext": true
+  }
+}
+```
+
+- **autoApprove**: When set to `true`, commands execute without requiring confirmation
+- **addToContext**: When set to `true`, `$` prefixed commands add output to context (this is a secondary gate)
+
+## Use Cases and Examples
+
+### When to Use the `!` Prefix
+
+Use `!` for commands that:
+- Are for your reference only
+- Would pollute the AI context with irrelevant information
+- Contain sensitive information you don't want shared with the AI
+- Are used frequently for system checks
+
+**Examples:**
+```
+!pwd                    # Check current directory
+!ls -la                 # List files without cluttering context
+!git status             # Check git status
+!ps aux | grep node     # Check running processes
+!npm run test           # Run tests without sharing results
+!docker ps              # Check running containers
+```
+
+### When to Use the `$` Prefix
+
+Use `$` for commands that:
+- Produce output relevant to your current conversation with the AI
+- Generate information you want the AI to analyze or reference
+- Set up context for your next questions
+
+**Examples:**
+```
+$cat config.json           # Share configuration file content
+$git diff                  # Show code changes for AI review
+$npm list --depth=0        # Show dependencies for context
+$grep -r "function" src/   # Find and share code patterns
+$curl -s api.example.com   # Share API responses for analysis
+```
+
+## Practical Workflow Examples
+
+### Workflow 1: Surgical Context Management
+```
+!git status                           # Check status without adding to context
+$git diff src/components/Button.tsx   # Share only relevant file changes
+What's wrong with my Button component implementation?
+```
+
+### Workflow 2: Keeping Secrets While Getting Help
+```
+!env | grep API_KEY                  # Check your API keys privately
+$grep -r "api.connect" src/ --include="*.js"   # Share only API usage patterns
+How should I structure my API calls for better security?
+```
+
+### Workflow 3: Test-Driven Development
+```
+!npm run test                        # Run tests privately to see what's failing
+$cat src/utils/validation.js         # Share the implementation
+$cat tests/utils/validation.test.js  # Share the failing test
+Why is my validation test failing?
+```
+
+### Workflow 4: Simple Context Test
+This workflow demonstrates how context is managed:
+```
+!echo "This is a secret that should NOT be in context"
+$echo "This information SHOULD be in context"
+What information did I just share with you in my commands?
+```
+The AI will only know about "This information SHOULD be in context" and will have no knowledge of the "secret".
+
+## Best Practices
+
+1. **Start with `!` by default**: Only use `$` when you specifically want information in context
+2. **Be context-conscious**: Remember that `$` commands count against your context limit
+3. **Use `$` sparingly**: For large outputs, consider filtering or using tools like `head`/`tail` 
+4. **Keep sensitive information behind `!`**: Never use `$` with commands that expose secrets
+5. **Chain commands thoughtfully**: Use `$` for final output but `!` for intermediate steps
+   ```
+   !cd src/components
+   $ls -la   # Only this output is added to context
+   ```
+6. **Curate context**: Use `$` only for the most relevant information
+
+## Advanced Usage
+
+### Combining with Pipes and Filters
+```
+$git log -n 5 --oneline   # Show recent commits but limit output
+$grep -A 5 -B 5 "bug" server.log   # Show error with context, but not whole log
+```
+
+### Using with Configuration Files
+```
+!ls ~/.codex          # Check what config files exist
+$cat ~/.codex/config.json | jq .   # Pretty-print and share your config
+```
+
+### Stateful Operations
+Remember that command state is preserved between commands, so you can:
+```
+!cd src/components
+!pwd                   # Confirms you're in the right directory
+$ls -la                # Lists the contents of the components directory
+```
+
+## Troubleshooting
+
+### Command Not Recognized as Direct Command
+- Ensure there's no space after the prefix: Use `!pwd` not `! pwd`
+- Make sure your Codex is updated to the version supporting this feature
+
+### AutoApproval Not Working
+- Check your config file with `!cat ~/.codex/config.json`
+- Ensure `"autoApprove": true` is set correctly
+- Try restarting Codex if config changes aren't taking effect
+
+### Output Not Added to Context
+- Verify you used `$` and not `!` prefix
+- Check your config has `"addToContext": true`
+- Be aware of context limits; very large outputs might be truncated
+
+## Conclusion
+
+Direct command execution bridges the gap between your terminal and AI assistant, giving you fine-grained control over what information is shared with the AI. By understanding when to use `!` versus `$`, you can maintain context efficiency, protect sensitive information, and optimize your workflow.
+
+The power of this feature lies in its simplicity: two characters that fundamentally change how you interact with both your system and your AI assistant. Use it wisely to make your Codex experience more productive and secure.

--- a/docs/features/git-github-approval-config.md
+++ b/docs/features/git-github-approval-config.md
@@ -1,0 +1,162 @@
+# Git and GitHub CLI Approval Configuration Guide
+
+## Overview
+
+Codex provides fine-grained control over approval requirements for Git and GitHub CLI commands. This feature allows you to:
+
+- Define which Git and GitHub CLI commands are automatically approved
+- Specify commands that always require explicit approval
+- Set default approval behavior for each tool
+- Override settings via command-line flags
+
+## Configuration Options
+
+You can configure Git and GitHub CLI approval settings in your `~/.codex/config.json` file:
+
+```json
+{
+  "git": {
+    "requireApprovalByDefault": true,
+    "autoApprovedCommands": [
+      "status",
+      "log",
+      "diff",
+      "branch",
+      "show"
+    ],
+    "requireApprovalCommands": [
+      "commit",
+      "push",
+      "merge",
+      "rebase",
+      "reset",
+      "checkout"
+    ]
+  },
+  "githubCli": {
+    "requireApprovalByDefault": false,
+    "autoApprovedCommands": [
+      "issue list",
+      "issue view",
+      "pr list",
+      "pr view",
+      "workflow list",
+      "workflow view"
+    ],
+    "requireApprovalCommands": [
+      "pr create",
+      "pr merge",
+      "issue create",
+      "issue close"
+    ]
+  }
+}
+```
+
+### Configuration Fields Explained
+
+#### Git Configuration
+
+- `requireApprovalByDefault`: When `true`, all Git commands require approval unless explicitly allowed. When `false`, commands are auto-approved unless explicitly denied. Default is `true` for safety.
+
+- `autoApprovedCommands`: List of Git subcommands that are always auto-approved regardless of the default setting. Default includes safe read-only commands like `status`, `log`, `diff`, `branch`, and `show`.
+
+- `requireApprovalCommands`: List of Git subcommands that always require approval regardless of the default setting. Default includes potentially destructive commands like `commit`, `push`, `merge`, `rebase`, `reset`, and `checkout`.
+
+#### GitHub CLI Configuration
+
+- `requireApprovalByDefault`: When `true`, all GitHub CLI commands require approval unless explicitly allowed. When `false`, commands are auto-approved unless explicitly denied. Default is `false` to maintain compatibility with existing behavior.
+
+- `autoApprovedCommands`: List of GitHub CLI subcommands that are always auto-approved regardless of the default setting. Default includes safe read-only commands like `issue list`, `pr list`, and various view operations.
+
+- `requireApprovalCommands`: List of GitHub CLI subcommands that always require approval regardless of the default setting. Default includes potentially destructive operations like `pr create`, `pr merge`, `issue create`, and `issue close`.
+
+## Command-Line Flags
+
+For quick configuration without modifying your config file, you can use these command-line flags:
+
+```bash
+# Always prompt for Git commands
+codex --git-approval=prompt "your prompt here"
+
+# Auto-approve Git commands (unless explicitly denied)
+codex --git-approval=auto "your prompt here"
+
+# Always prompt for GitHub CLI commands
+codex --github-approval=prompt "your prompt here"
+
+# Auto-approve GitHub CLI commands (unless explicitly denied)
+codex --github-approval=auto "your prompt here"
+```
+
+## Usage Examples
+
+### Example 1: Default Behavior
+
+With default settings:
+- Git commands like `status`, `log`, `diff` will be auto-approved
+- Git commands like `commit`, `push`, `merge` will require approval
+- Any other Git command will require approval (default is `requireApprovalByDefault: true`)
+- GitHub CLI commands like `issue list`, `pr view` will be auto-approved
+- GitHub CLI commands like `pr create`, `issue close` will require approval
+- Any other GitHub CLI command will be auto-approved (default is `requireApprovalByDefault: false`)
+
+### Example 2: Custom Configuration
+
+If you want to:
+- Auto-approve all Git commands except potentially destructive ones
+- Require approval for all GitHub CLI commands
+
+```json
+{
+  "git": {
+    "requireApprovalByDefault": false,
+    "requireApprovalCommands": [
+      "commit", "push", "merge", "rebase", "reset", "checkout",
+      "branch -D", "clean", "stash"
+    ]
+  },
+  "githubCli": {
+    "requireApprovalByDefault": true,
+    "autoApprovedCommands": [
+      "issue list", "issue view", "pr list", "pr view"
+    ]
+  }
+}
+```
+
+### Example 3: Command-Line Override
+
+To temporarily change approval behavior for a single session:
+
+```bash
+# Ask for prompt on all git commands for this session only
+codex --git-approval=prompt "Clone the repo and analyze the code structure"
+
+# Auto-approve GitHub CLI commands for this session only
+codex --github-approval=auto "Create a PR for my feature branch"
+```
+
+## Safety Considerations
+
+- By default, Git commands require approval (safer)
+- GitHub CLI commands are auto-approved by default to maintain compatibility with existing behavior
+- When in doubt about a command's safety, prefer `requireApprovalByDefault: true`
+- Commands that modify state should typically be in `requireApprovalCommands`
+- Read-only commands are good candidates for `autoApprovedCommands`
+
+## Recommended Workflow
+
+1. Start with the default configuration
+2. Add commonly used safe commands to `autoApprovedCommands` 
+3. Add potentially destructive commands to `requireApprovalCommands`
+4. Use command-line flags for temporary overrides
+
+## Troubleshooting
+
+- If commands are being auto-approved unexpectedly, check if `requireApprovalByDefault` is `false`
+- If commands are requiring approval unexpectedly, check if they're listed in `requireApprovalCommands`
+- Command-line flags override configuration file settings for the current session
+- Multi-word commands for GitHub CLI (e.g., `issue list`) must be entered exactly as shown
+
+By configuring these settings appropriately, you can balance convenience and safety when working with Git and GitHub CLI commands in Codex.


### PR DESCRIPTION
## Summary

This PR adds configurable approval settings for Git and GitHub CLI commands:

- Added configuration settings for Git and GitHub CLI command approval
- Implemented fine-grained control with auto-approved and required-approval command lists
- Added command-line flags for quick toggles (--git-approval, --github-approval)
- Created comprehensive tests to verify behavior
- Added detailed documentation with examples and best practices

## Testing

To test this feature:
1. Configure settings in ~/.codex/config.json or use command-line flags
2. Try running different Git and GitHub CLI commands to see approval behavior
3. Verify that commands in auto-approved list are auto-approved
4. Verify that commands in required-approval list always require approval

Closes #8