### PR TITLE
Implement Provider Interface and Registry

### DIFF
--- a/codex-cli/src/utils/providers/base-provider.ts
+++ b/codex-cli/src/utils/providers/base-provider.ts
@@ -1,0 +1,254 @@
+/**
+ * Base provider implementation with common functionality
+ */
+
+import type { AppConfig } from "../config.js";
+import {
+  LLMProvider,
+  CompletionParams,
+  ModelDefaults,
+  ParsedToolCall,
+  Tool,
+  NormalizedStreamEvent,
+  ProviderErrorType,
+  StandardizedError,
+} from "./provider-interface.js";
+
+/**
+ * Abstract base class implementing common functionality for all providers
+ */
+export abstract class BaseProvider implements LLMProvider {
+  /** Unique provider identifier */
+  abstract id: string;
+  
+  /** Display name for the provider */
+  abstract name: string;
+  
+  /**
+   * Get available models from this provider
+   */
+  abstract getModels(): Promise<string[]>;
+  
+  /**
+   * Create a client instance for this provider
+   */
+  abstract createClient(config: AppConfig): any;
+  
+  /**
+   * Execute a completion request
+   */
+  abstract runCompletion(params: CompletionParams): Promise<any>;
+  
+  /**
+   * Get default configuration for a specific model
+   */
+  abstract getModelDefaults(model: string): ModelDefaults;
+  
+  /**
+   * Parse a tool call from provider-specific format to common format
+   */
+  abstract parseToolCall(rawToolCall: any): ParsedToolCall;
+  
+  /**
+   * Format tools into provider-specific format
+   */
+  abstract formatTools(tools: Tool[]): any;
+  
+  /**
+   * Normalize a stream event from provider-specific format to common format
+   */
+  abstract normalizeStreamEvent(event: any): NormalizedStreamEvent;
+  
+  /**
+   * Check if a model is supported by this provider
+   * Default implementation that can be overridden
+   */
+  async isModelSupported(model: string): Promise<boolean> {
+    try {
+      const models = await this.getModels();
+      return models.includes(model);
+    } catch (error) {
+      console.error(`Error checking if model ${model} is supported:`, error);
+      return false;
+    }
+  }
+  
+  /**
+   * Check if an error is a rate limit error for this provider
+   * Default implementation that should be overridden by specific providers
+   */
+  isRateLimitError(error: any): boolean {
+    // Default implementation looks for common patterns
+    return (
+      error?.status === 429 ||
+      error?.statusCode === 429 ||
+      error?.code === "rate_limit_exceeded" ||
+      error?.type === "rate_limit_exceeded" ||
+      /rate limit/i.test(error?.message || "") ||
+      /too many requests/i.test(error?.message || "")
+    );
+  }
+  
+  /**
+   * Check if an error is a timeout error for this provider
+   * Default implementation that should be overridden by specific providers
+   */
+  isTimeoutError(error: any): boolean {
+    // Default implementation looks for common patterns
+    return (
+      error?.name === "AbortError" ||
+      error?.code === "ETIMEDOUT" ||
+      error?.code === "ESOCKETTIMEDOUT" ||
+      /timeout/i.test(error?.message || "") ||
+      /timed out/i.test(error?.message || "")
+    );
+  }
+  
+  /**
+   * Check if an error is a connection error for this provider
+   * Default implementation that should be overridden by specific providers
+   */
+  isConnectionError(error: any): boolean {
+    // Default implementation looks for common patterns
+    return (
+      error?.code === "ECONNRESET" ||
+      error?.code === "ECONNREFUSED" ||
+      error?.code === "ENOTFOUND" ||
+      error?.code === "EPIPE" ||
+      error?.code === "ENETUNREACH" ||
+      /network/i.test(error?.message || "") ||
+      /connection/i.test(error?.message || "")
+    );
+  }
+  
+  /**
+   * Check if an error is a context length error for this provider
+   * Default implementation that should be overridden by specific providers
+   */
+  isContextLengthError(error: any): boolean {
+    // Default implementation looks for common patterns
+    return (
+      error?.code === "context_length_exceeded" ||
+      /maximum context length/i.test(error?.message || "") ||
+      /too many tokens/i.test(error?.message || "") ||
+      /context window is full/i.test(error?.message || "")
+    );
+  }
+  
+  /**
+   * Check if an error is an invalid request error for this provider
+   * Default implementation that should be overridden by specific providers
+   */
+  isInvalidRequestError(error: any): boolean {
+    // Default implementation looks for common patterns
+    return (
+      (error?.status >= 400 && error?.status < 500 && error?.status !== 429) ||
+      error?.type === "invalid_request_error" ||
+      error?.code === "invalid_request_error"
+    );
+  }
+  
+  /**
+   * Format an error message for user display
+   * Default implementation that should be overridden by specific providers
+   */
+  formatErrorMessage(error: any): string {
+    if (error?.message) {
+      return `API Error: ${error.message}`;
+    } else if (error?.error?.message) {
+      return `API Error: ${error.error.message}`;
+    } else {
+      return "Unknown API error occurred";
+    }
+  }
+  
+  /**
+   * Get the recommended wait time for rate limit errors
+   * Default implementation that should be overridden by specific providers
+   */
+  getRetryAfterMs(error: any): number {
+    // Check for retry-after header (in seconds)
+    const retryAfter = error?.headers?.["retry-after"] || 
+                       error?.response?.headers?.["retry-after"];
+    
+    if (retryAfter && !isNaN(parseInt(retryAfter, 10))) {
+      return parseInt(retryAfter, 10) * 1000;
+    }
+    
+    // Check for retry-after in error message
+    const message = error?.message || "";
+    const match = /(?:retry|try) again in ([\d.]+)s/i.exec(message);
+    if (match && match[1] && !isNaN(parseFloat(match[1]))) {
+      return parseFloat(match[1]) * 1000;
+    }
+    
+    // Default to 2.5 seconds
+    return 2500;
+  }
+  
+  /**
+   * Standardize an error from provider-specific format
+   * @param error Provider-specific error
+   * @returns Standardized error
+   */
+  standardizeError(error: any): StandardizedError {
+    if (this.isRateLimitError(error)) {
+      return {
+        type: ProviderErrorType.RATE_LIMIT,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: true,
+        suggestedWaitMs: this.getRetryAfterMs(error),
+      };
+    } else if (this.isTimeoutError(error)) {
+      return {
+        type: ProviderErrorType.TIMEOUT,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: true,
+      };
+    } else if (this.isConnectionError(error)) {
+      return {
+        type: ProviderErrorType.NETWORK,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: true,
+      };
+    } else if (this.isContextLengthError(error)) {
+      return {
+        type: ProviderErrorType.CONTEXT_LENGTH,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: false,
+      };
+    } else if (this.isInvalidRequestError(error)) {
+      return {
+        type: ProviderErrorType.INVALID_REQUEST,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: false,
+      };
+    } else if (error?.status >= 500) {
+      return {
+        type: ProviderErrorType.SERVER,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: true,
+      };
+    } else if (error?.status === 401 || error?.status === 403) {
+      return {
+        type: ProviderErrorType.AUTHENTICATION,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: false,
+      };
+    } else {
+      return {
+        type: ProviderErrorType.UNKNOWN,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: false,
+      };
+    }
+  }
+}

--- a/codex-cli/src/utils/providers/base-provider.ts
+++ b/codex-cli/src/utils/providers/base-provider.ts
@@ -192,7 +192,15 @@ export abstract class BaseProvider implements LLMProvider {
    * @returns Standardized error
    */
   standardizeError(error: any): StandardizedError {
-    if (this.isRateLimitError(error)) {
+    // Check for authentication errors first
+    if (error?.status === 401 || error?.status === 403) {
+      return {
+        type: ProviderErrorType.AUTHENTICATION,
+        message: this.formatErrorMessage(error),
+        originalError: error,
+        retryable: false,
+      };
+    } else if (this.isRateLimitError(error)) {
       return {
         type: ProviderErrorType.RATE_LIMIT,
         message: this.formatErrorMessage(error),
@@ -234,13 +242,6 @@ export abstract class BaseProvider implements LLMProvider {
         message: this.formatErrorMessage(error),
         originalError: error,
         retryable: true,
-      };
-    } else if (error?.status === 401 || error?.status === 403) {
-      return {
-        type: ProviderErrorType.AUTHENTICATION,
-        message: this.formatErrorMessage(error),
-        originalError: error,
-        retryable: false,
       };
     } else {
       return {

--- a/codex-cli/src/utils/providers/index.ts
+++ b/codex-cli/src/utils/providers/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Provider exports for multi-provider support
+ */
+
+// Export interfaces and types
+export * from "./provider-interface.js";
+
+// Export base provider
+export * from "./base-provider.js";
+
+// Export provider registry
+export * from "./provider-registry.js";
+
+// Convenience method to get provider for a model
+import { ProviderRegistry } from "./provider-registry.js";
+export const getProviderForModel = ProviderRegistry.getProviderForModel.bind(ProviderRegistry);
+
+// Convenience method to get the default provider
+export const getDefaultProvider = ProviderRegistry.getDefaultProvider.bind(ProviderRegistry);

--- a/codex-cli/src/utils/providers/provider-interface.ts
+++ b/codex-cli/src/utils/providers/provider-interface.ts
@@ -1,0 +1,325 @@
+/**
+ * Provider interface for multi-provider support in Codex CLI.
+ * This interface defines the contract that all LLM providers must implement.
+ */
+
+import type { AppConfig } from "../config.js";
+import type {
+  ResponseFunctionToolCall,
+  ResponseInputItem,
+  ResponseItem,
+} from "openai/resources/responses/responses.mjs";
+
+/**
+ * Core interface that all LLM providers must implement
+ */
+export interface LLMProvider {
+  /** Unique identifier for the provider */
+  id: string;
+  
+  /** Display name for the provider */
+  name: string;
+  
+  /**
+   * Get available models from this provider
+   * @returns Promise resolving to an array of model identifiers
+   */
+  getModels(): Promise<string[]>;
+  
+  /**
+   * Check if a model is supported by this provider
+   * @param model Model identifier to check
+   * @returns Promise resolving to true if the model is supported
+   */
+  isModelSupported(model: string): Promise<boolean>;
+  
+  /**
+   * Create a client instance for this provider
+   * @param config Application configuration
+   * @returns Provider-specific client instance
+   */
+  createClient(config: AppConfig): any;
+  
+  /**
+   * Execute a completion request
+   * @param params Completion parameters
+   * @returns Promise resolving to a stream of completion events
+   */
+  runCompletion(params: CompletionParams): Promise<any>;
+  
+  /**
+   * Get default configuration for a specific model
+   * @param model Model identifier
+   * @returns Model-specific default settings
+   */
+  getModelDefaults(model: string): ModelDefaults;
+  
+  /**
+   * Check if an error is a rate limit error for this provider
+   * @param error Provider-specific error
+   * @returns True if the error is a rate limit error
+   */
+  isRateLimitError(error: any): boolean;
+  
+  /**
+   * Check if an error is a timeout error for this provider
+   * @param error Provider-specific error
+   * @returns True if the error is a timeout error
+   */
+  isTimeoutError(error: any): boolean;
+  
+  /**
+   * Check if an error is a connection error for this provider
+   * @param error Provider-specific error
+   * @returns True if the error is a connection error
+   */
+  isConnectionError(error: any): boolean;
+  
+  /**
+   * Check if an error is a context length error for this provider
+   * @param error Provider-specific error
+   * @returns True if the error is a context length error
+   */
+  isContextLengthError(error: any): boolean;
+  
+  /**
+   * Check if an error is an invalid request error for this provider
+   * @param error Provider-specific error
+   * @returns True if the error is an invalid request error
+   */
+  isInvalidRequestError(error: any): boolean;
+  
+  /**
+   * Format an error message for user display
+   * @param error Provider-specific error
+   * @returns User-friendly error message
+   */
+  formatErrorMessage(error: any): string;
+  
+  /**
+   * Get the recommended wait time for rate limit errors
+   * @param error Provider-specific error
+   * @returns Recommended wait time in milliseconds
+   */
+  getRetryAfterMs(error: any): number;
+  
+  /**
+   * Parse a tool call from provider-specific format to common format
+   * @param rawToolCall Provider-specific tool call
+   * @returns Normalized tool call
+   */
+  parseToolCall(rawToolCall: any): ParsedToolCall;
+  
+  /**
+   * Format tools into provider-specific format
+   * @param tools Array of tools in common format
+   * @returns Tools in provider-specific format
+   */
+  formatTools(tools: Tool[]): any;
+  
+  /**
+   * Normalize a stream event from provider-specific format to common format
+   * @param event Provider-specific stream event
+   * @returns Normalized event in common format
+   */
+  normalizeStreamEvent(event: any): NormalizedStreamEvent;
+}
+
+/**
+ * Common parameters for completion requests
+ */
+export interface CompletionParams {
+  /** Model identifier */
+  model: string;
+  
+  /** Messages for the conversation */
+  messages: Message[];
+  
+  /** Tools available to the model */
+  tools?: Tool[];
+  
+  /** Temperature parameter (0.0-2.0) */
+  temperature?: number;
+  
+  /** Whether to stream the response */
+  stream?: boolean;
+  
+  /** Previous response ID for continuations */
+  previousResponseId?: string;
+  
+  /** Max tokens to generate */
+  maxTokens?: number;
+  
+  /** Whether to use parallel tool calls */
+  parallelToolCalls?: boolean;
+  
+  /** Reasoning settings */
+  reasoning?: ReasoningSettings;
+  
+  /** Application configuration */
+  config: AppConfig;
+}
+
+/**
+ * Model defaults for provider configuration
+ */
+export interface ModelDefaults {
+  /** Default timeout for this model in milliseconds */
+  timeoutMs: number;
+  
+  /** Default temperature for this model */
+  temperature?: number;
+  
+  /** Maximum tokens supported by this model */
+  maxTokens?: number;
+  
+  /** Whether this model supports tool/function calling */
+  supportsToolCalls: boolean;
+  
+  /** Whether this model supports streaming */
+  supportsStreaming: boolean;
+  
+  /** Maximum context window size in tokens */
+  contextWindowSize: number;
+}
+
+/**
+ * Message representation for providers
+ */
+export interface Message {
+  /** Message role */
+  role: "system" | "user" | "assistant" | "function" | "tool";
+  
+  /** Message content */
+  content: string | MessageContent[];
+  
+  /** Optional name for the message sender */
+  name?: string;
+  
+  /** Tool outputs (for tool messages) */
+  toolOutputs?: ToolOutput[];
+}
+
+/**
+ * Structure for message content items
+ */
+export interface MessageContent {
+  /** Content type */
+  type: "text" | "image_url";
+  
+  /** Text content */
+  text?: string;
+  
+  /** Image URL data */
+  image_url?: {
+    url: string;
+    detail?: "low" | "high" | "auto";
+  };
+}
+
+/**
+ * Tool definition for providers
+ */
+export interface Tool {
+  /** Tool type */
+  type: "function";
+  
+  /** Tool name */
+  name: string;
+  
+  /** Tool description */
+  description?: string;
+  
+  /** Parameters schema */
+  parameters: object;
+  
+  /** Whether to use strict parameter validation */
+  strict?: boolean;
+}
+
+/**
+ * Normalized tool call for consistent handling
+ */
+export interface ParsedToolCall {
+  /** Tool call ID */
+  id: string;
+  
+  /** Tool name */
+  name: string;
+  
+  /** Tool arguments */
+  arguments: any;
+}
+
+/**
+ * Structure for tool outputs
+ */
+export interface ToolOutput {
+  /** Tool call ID this output corresponds to */
+  tool_call_id: string;
+  
+  /** Output content */
+  output: string;
+}
+
+/**
+ * Reasoning settings for models that support it
+ */
+export interface ReasoningSettings {
+  /** Reasoning effort level */
+  effort?: "low" | "medium" | "high" | "auto";
+  
+  /** Whether to include reasoning summary */
+  summary?: boolean;
+}
+
+/**
+ * Normalized stream event type for consistent handling
+ */
+export interface NormalizedStreamEvent {
+  /** Event type */
+  type: "text" | "tool_call" | "completion" | "error";
+  
+  /** Event content */
+  content?: string | object;
+  
+  /** Response ID */
+  responseId?: string;
+  
+  /** Original event */
+  originalEvent: any;
+}
+
+/**
+ * Provider error types for standardized error handling
+ */
+export enum ProviderErrorType {
+  AUTHENTICATION = "authentication_error",
+  RATE_LIMIT = "rate_limit_error",
+  CONTEXT_LENGTH = "context_length_error",
+  INVALID_REQUEST = "invalid_request_error",
+  SERVER = "server_error",
+  NETWORK = "network_error",
+  TIMEOUT = "timeout_error",
+  UNKNOWN = "unknown_error",
+}
+
+/**
+ * Standardized error for consistent error handling
+ */
+export interface StandardizedError {
+  /** Error type */
+  type: ProviderErrorType;
+  
+  /** Error message */
+  message: string;
+  
+  /** Original error */
+  originalError: any;
+  
+  /** Whether the error is retryable */
+  retryable: boolean;
+  
+  /** Suggested wait time in milliseconds before retry */
+  suggestedWaitMs?: number;
+}

--- a/codex-cli/src/utils/providers/provider-registry.ts
+++ b/codex-cli/src/utils/providers/provider-registry.ts
@@ -1,0 +1,125 @@
+/**
+ * Provider registry for managing LLM providers
+ */
+
+import { LLMProvider } from "./provider-interface.js";
+
+/**
+ * Registry for managing and accessing LLM providers
+ */
+export class ProviderRegistry {
+  /** Map of registered providers by ID */
+  private static providers: Map<string, LLMProvider> = new Map();
+  
+  /** Default provider ID */
+  private static defaultProviderId: string = "openai";
+  
+  /**
+   * Register a provider with the registry
+   * @param provider Provider to register
+   */
+  static register(provider: LLMProvider): void {
+    this.providers.set(provider.id, provider);
+  }
+  
+  /**
+   * Get a provider by ID
+   * @param id Provider ID
+   * @returns The provider, or undefined if not found
+   */
+  static getProviderById(id: string): LLMProvider | undefined {
+    return this.providers.get(id);
+  }
+  
+  /**
+   * Set the default provider ID
+   * @param id Provider ID to use as default
+   */
+  static setDefaultProviderId(id: string): void {
+    if (this.providers.has(id)) {
+      this.defaultProviderId = id;
+    } else {
+      throw new Error(`Cannot set default provider: provider with ID "${id}" not registered`);
+    }
+  }
+  
+  /**
+   * Get the default provider ID
+   * @returns The current default provider ID
+   */
+  static getDefaultProviderId(): string {
+    return this.defaultProviderId;
+  }
+  
+  /**
+   * Get a provider for a specific model
+   * @param model Model identifier
+   * @returns The appropriate provider for the model
+   */
+  static getProviderForModel(model: string): LLMProvider {
+    // Detect provider from model name pattern
+    if (model.startsWith("claude")) {
+      return this.getProviderById("claude") || this.getDefaultProvider();
+    }
+    
+    // Detect OpenAI models
+    if (
+      model.startsWith("gpt-") ||
+      model.startsWith("o") ||
+      model.startsWith("text-") ||
+      model === "gpt-4" ||
+      model === "gpt-3.5-turbo"
+    ) {
+      return this.getProviderById("openai") || this.getDefaultProvider();
+    }
+    
+    // Default to the default provider
+    return this.getDefaultProvider();
+  }
+  
+  /**
+   * Get the default provider
+   * @returns Default provider, or first available provider
+   * @throws Error if no providers are registered
+   */
+  static getDefaultProvider(): LLMProvider {
+    const defaultProvider = this.getProviderById(this.defaultProviderId);
+    if (defaultProvider) {
+      return defaultProvider;
+    }
+    
+    // Fallback to first available provider
+    const providers = Array.from(this.providers.values());
+    if (providers.length > 0) {
+      return providers[0];
+    }
+    
+    throw new Error("No LLM providers registered");
+  }
+  
+  /**
+   * Get all registered providers
+   * @returns Array of all providers
+   */
+  static getAllProviders(): LLMProvider[] {
+    return Array.from(this.providers.values());
+  }
+  
+  /**
+   * Check if a provider is registered
+   * @param id Provider ID
+   * @returns True if the provider is registered
+   */
+  static hasProvider(id: string): boolean {
+    return this.providers.has(id);
+  }
+  
+  /**
+   * Clear all registered providers
+   * Primarily used for testing
+   */
+  static clearProviders(): void {
+    this.providers.clear();
+    this.defaultProviderId = "openai";
+  }
+}

--- a/codex-cli/tests/base-provider.test.ts
+++ b/codex-cli/tests/base-provider.test.ts
@@ -1,0 +1,191 @@
+import { BaseProvider, ProviderErrorType } from "../src/utils/providers";
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Mock provider implementation for testing
+class TestProvider extends BaseProvider {
+  id = "test";
+  name = "Test Provider";
+  
+  async getModels() {
+    return ["test-model-1", "test-model-2"];
+  }
+  
+  createClient() {
+    return { id: this.id };
+  }
+  
+  async runCompletion() {
+    return { id: "test-completion" };
+  }
+  
+  getModelDefaults() {
+    return {
+      timeoutMs: 30000,
+      supportsToolCalls: true,
+      supportsStreaming: true,
+      contextWindowSize: 8192,
+    };
+  }
+  
+  parseToolCall(rawToolCall: any) {
+    return {
+      id: rawToolCall.id || "test-id",
+      name: rawToolCall.name || "test-name",
+      arguments: rawToolCall.arguments || {},
+    };
+  }
+  
+  formatTools(tools: any[]) {
+    return tools;
+  }
+  
+  normalizeStreamEvent(event: any) {
+    return {
+      type: "text",
+      content: "test content",
+      responseId: "test-id",
+      originalEvent: event,
+    };
+  }
+}
+
+describe("BaseProvider", () => {
+  let provider: TestProvider;
+  
+  beforeEach(() => {
+    provider = new TestProvider();
+  });
+  
+  describe("isModelSupported", () => {
+    it("returns true for supported models", async () => {
+      const isSupported = await provider.isModelSupported("test-model-1");
+      expect(isSupported).toBe(true);
+    });
+    
+    it("returns false for unsupported models", async () => {
+      const isSupported = await provider.isModelSupported("unsupported-model");
+      expect(isSupported).toBe(false);
+    });
+  });
+  
+  describe("error detection", () => {
+    it("detects rate limit errors", () => {
+      expect(provider.isRateLimitError({ status: 429 })).toBe(true);
+      expect(provider.isRateLimitError({ code: "rate_limit_exceeded" })).toBe(true);
+      expect(provider.isRateLimitError({ type: "rate_limit_exceeded" })).toBe(true);
+      expect(provider.isRateLimitError({ message: "Rate limit exceeded" })).toBe(true);
+      expect(provider.isRateLimitError({ message: "Too many requests" })).toBe(true);
+      expect(provider.isRateLimitError({ status: 400 })).toBe(false);
+    });
+    
+    it("detects timeout errors", () => {
+      expect(provider.isTimeoutError({ name: "AbortError" })).toBe(true);
+      expect(provider.isTimeoutError({ code: "ETIMEDOUT" })).toBe(true);
+      expect(provider.isTimeoutError({ message: "Request timed out" })).toBe(true);
+      expect(provider.isTimeoutError({ status: 400 })).toBe(false);
+    });
+    
+    it("detects connection errors", () => {
+      expect(provider.isConnectionError({ code: "ECONNRESET" })).toBe(true);
+      expect(provider.isConnectionError({ code: "ECONNREFUSED" })).toBe(true);
+      expect(provider.isConnectionError({ message: "Network error" })).toBe(true);
+      expect(provider.isConnectionError({ status: 400 })).toBe(false);
+    });
+    
+    it("detects context length errors", () => {
+      expect(provider.isContextLengthError({ code: "context_length_exceeded" })).toBe(true);
+      expect(provider.isContextLengthError({ message: "Maximum context length exceeded" })).toBe(true);
+      expect(provider.isContextLengthError({ message: "Too many tokens" })).toBe(true);
+      expect(provider.isContextLengthError({ status: 400 })).toBe(false);
+    });
+    
+    it("detects invalid request errors", () => {
+      expect(provider.isInvalidRequestError({ status: 400 })).toBe(true);
+      expect(provider.isInvalidRequestError({ type: "invalid_request_error" })).toBe(true);
+      expect(provider.isInvalidRequestError({ status: 500 })).toBe(false);
+      expect(provider.isInvalidRequestError({ status: 429 })).toBe(false);
+    });
+  });
+  
+  describe("error formatting", () => {
+    it("formats error messages from different structures", () => {
+      expect(provider.formatErrorMessage({ message: "Test error" }))
+        .toBe("API Error: Test error");
+      
+      expect(provider.formatErrorMessage({ error: { message: "Nested error" } }))
+        .toBe("API Error: Nested error");
+      
+      expect(provider.formatErrorMessage({}))
+        .toBe("Unknown API error occurred");
+    });
+  });
+  
+  describe("retry timing", () => {
+    it("extracts retry-after from headers", () => {
+      const error = { headers: { "retry-after": "5" } };
+      expect(provider.getRetryAfterMs(error)).toBe(5000);
+    });
+    
+    it("extracts retry timing from error message", () => {
+      const error = { message: "Rate limit exceeded. Retry again in 2.5s" };
+      expect(provider.getRetryAfterMs(error)).toBe(2500);
+    });
+    
+    it("returns default retry time if not specified", () => {
+      const error = { message: "Rate limit exceeded" };
+      expect(provider.getRetryAfterMs(error)).toBe(2500);
+    });
+  });
+  
+  describe("error standardization", () => {
+    it("standardizes rate limit errors", () => {
+      const error = { status: 429, message: "Rate limit exceeded" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.RATE_LIMIT);
+      expect(standardized.message).toBe("API Error: Rate limit exceeded");
+      expect(standardized.retryable).toBe(true);
+      expect(standardized.originalError).toBe(error);
+    });
+    
+    it("standardizes timeout errors", () => {
+      const error = { code: "ETIMEDOUT", message: "Request timed out" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.TIMEOUT);
+      expect(standardized.retryable).toBe(true);
+    });
+    
+    it("standardizes context length errors", () => {
+      const error = { code: "context_length_exceeded", message: "Too many tokens" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.CONTEXT_LENGTH);
+      expect(standardized.retryable).toBe(false);
+    });
+    
+    it("standardizes authentication errors", () => {
+      const error = { status: 401, message: "Invalid API key" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.AUTHENTICATION);
+      expect(standardized.retryable).toBe(false);
+    });
+    
+    it("standardizes server errors", () => {
+      const error = { status: 500, message: "Internal server error" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.SERVER);
+      expect(standardized.retryable).toBe(true);
+    });
+    
+    it("standardizes unknown errors", () => {
+      const error = { message: "Some weird error" };
+      const standardized = provider.standardizeError(error);
+      
+      expect(standardized.type).toBe(ProviderErrorType.UNKNOWN);
+      expect(standardized.retryable).toBe(false);
+    });
+  });
+});

--- a/codex-cli/tests/provider-registry.test.ts
+++ b/codex-cli/tests/provider-registry.test.ts
@@ -1,0 +1,129 @@
+import { BaseProvider, LLMProvider, ProviderRegistry } from "../src/utils/providers";
+import type { AppConfig } from "../src/utils/config";
+import { describe, it, expect, beforeEach } from "vitest";
+
+// Mock provider implementation for testing
+class MockProvider extends BaseProvider implements LLMProvider {
+  constructor(public id: string, public name: string) {
+    super();
+  }
+  
+  async getModels() {
+    return [`${this.id}-model-1`, `${this.id}-model-2`];
+  }
+  
+  createClient() {
+    return { id: this.id };
+  }
+  
+  async runCompletion() {
+    return { id: "mock-completion" };
+  }
+  
+  getModelDefaults() {
+    return {
+      timeoutMs: 30000,
+      supportsToolCalls: true,
+      supportsStreaming: true,
+      contextWindowSize: 8192,
+    };
+  }
+  
+  parseToolCall(rawToolCall: any) {
+    return {
+      id: rawToolCall.id || "mock-id",
+      name: rawToolCall.name || "mock-name",
+      arguments: rawToolCall.arguments || {},
+    };
+  }
+  
+  formatTools(tools: any[]) {
+    return tools;
+  }
+  
+  normalizeStreamEvent(event: any) {
+    return {
+      type: "text",
+      content: "mock content",
+      responseId: "mock-id",
+      originalEvent: event,
+    };
+  }
+}
+
+describe("ProviderRegistry", () => {
+  beforeEach(() => {
+    // Clear registry before each test
+    ProviderRegistry.clearProviders();
+  });
+  
+  it("registers and retrieves providers", () => {
+    const openaiProvider = new MockProvider("openai", "OpenAI");
+    const claudeProvider = new MockProvider("claude", "Claude");
+    
+    ProviderRegistry.register(openaiProvider);
+    ProviderRegistry.register(claudeProvider);
+    
+    expect(ProviderRegistry.getProviderById("openai")).toBe(openaiProvider);
+    expect(ProviderRegistry.getProviderById("claude")).toBe(claudeProvider);
+    expect(ProviderRegistry.getAllProviders().length).toBe(2);
+    expect(ProviderRegistry.hasProvider("openai")).toBe(true);
+    expect(ProviderRegistry.hasProvider("nonexistent")).toBe(false);
+  });
+  
+  it("returns the default provider", () => {
+    const openaiProvider = new MockProvider("openai", "OpenAI");
+    ProviderRegistry.register(openaiProvider);
+    
+    expect(ProviderRegistry.getDefaultProvider()).toBe(openaiProvider);
+    expect(ProviderRegistry.getDefaultProviderId()).toBe("openai");
+  });
+  
+  it("allows changing the default provider", () => {
+    const openaiProvider = new MockProvider("openai", "OpenAI");
+    const claudeProvider = new MockProvider("claude", "Claude");
+    
+    ProviderRegistry.register(openaiProvider);
+    ProviderRegistry.register(claudeProvider);
+    
+    ProviderRegistry.setDefaultProviderId("claude");
+    
+    expect(ProviderRegistry.getDefaultProvider()).toBe(claudeProvider);
+    expect(ProviderRegistry.getDefaultProviderId()).toBe("claude");
+  });
+  
+  it("throws when setting a non-existent provider as default", () => {
+    expect(() => {
+      ProviderRegistry.setDefaultProviderId("nonexistent");
+    }).toThrow();
+  });
+  
+  it("throws when no providers are registered", () => {
+    expect(() => {
+      ProviderRegistry.getDefaultProvider();
+    }).toThrow("No LLM providers registered");
+  });
+  
+  it("selects the correct provider based on model name", () => {
+    const openaiProvider = new MockProvider("openai", "OpenAI");
+    const claudeProvider = new MockProvider("claude", "Claude");
+    
+    ProviderRegistry.register(openaiProvider);
+    ProviderRegistry.register(claudeProvider);
+    
+    expect(ProviderRegistry.getProviderForModel("gpt-4")).toBe(openaiProvider);
+    expect(ProviderRegistry.getProviderForModel("o4-mini")).toBe(openaiProvider);
+    expect(ProviderRegistry.getProviderForModel("claude-3-opus")).toBe(claudeProvider);
+    
+    // Unknown model should return default
+    expect(ProviderRegistry.getProviderForModel("unknown-model")).toBe(openaiProvider);
+  });
+  
+  it("falls back to default provider if requested provider not found", () => {
+    const openaiProvider = new MockProvider("openai", "OpenAI");
+    ProviderRegistry.register(openaiProvider);
+    
+    // Claude model but no Claude provider registered
+    expect(ProviderRegistry.getProviderForModel("claude-3-opus")).toBe(openaiProvider);
+  });
+});


### PR DESCRIPTION
## Description
This PR implements the provider abstraction layer for multi-provider support.

## Changes
- Create LLMProvider interface with comprehensive method definitions
- Implement BaseProvider abstract class with common functionality
- Create ProviderRegistry for managing and selecting providers
- Add unit tests for provider registry and base provider

## Testing
All tests pass for provider-registry.test.ts and base-provider.test.ts.

## Related Issues
This PR addresses:
- Issue #18: Milestone 1.1: Create LLMProvider Interface
- Issue #19: Milestone 1.2: Implement Provider Registry

This is the first step in implementing multi-provider support for Codex CLI (parent issue #11).