### PR TITLE
Fix duplicated conversion logic in ClaudeProvider (#40)

### DIFF
--- a/codex-cli/src/utils/providers/base-provider.ts
+++ b/codex-cli/src/utils/providers/base-provider.ts
@@ -131,6 +131,7 @@ export abstract class BaseProvider implements LLMProvider {
       error?.code === "context_length_exceeded" ||
       /maximum context length/i.test(error?.message || "") ||
       /too many tokens/i.test(error?.message || "") ||
+      /max tokens/i.test(error?.message || "") ||
       /context window is full/i.test(error?.message || "")
     );
   }

--- a/codex-cli/src/utils/providers/index.ts
+++ b/codex-cli/src/utils/providers/index.ts
@@ -36,6 +36,11 @@ export function initializeProviderRegistry(): void {
 export { ProviderRegistry } from "./provider-registry.js";
 
 /**
+ * Export provider constructors
+ */
+export { OpenAIProvider } from "./openai-provider.js";
+export { ClaudeProvider } from "./claude-provider.js";
+/**
  * Export provider types
  */
 export type { LLMProvider, CompletionParams } from "./provider-interface.js";


### PR DESCRIPTION
**Summary**

This PR addresses issue #40 by:

- Removing the unused  wrapper from .
- Returning the raw Anthropic client directly.
- Consolidating all message conversion and API calls into .
- Adding a new smoke test to verify non-streaming  behavior.
- Updating tests for  and error-formatting to match static behavior.

All existing and new tests pass on this branch.
